### PR TITLE
feat: AuditorAware 구현

### DIFF
--- a/com.three-iii.user/docs/client/auth-api.http
+++ b/com.three-iii.user/docs/client/auth-api.http
@@ -19,7 +19,7 @@ Content-Type: application/json
   "password": "password",
   "slackId": "master",
   "master": true,
-  "masterToken": "MASTER_TOKEN_AI_B2B_THREE_III1"
+  "masterToken": "MASTER_TOKEN_AI_B2B_THREE_III"
 }
 
 ### 일반 사용자 로그인 API

--- a/com.three-iii.user/docs/client/shippers-api.http
+++ b/com.three-iii.user/docs/client/shippers-api.http
@@ -4,7 +4,7 @@ Content-Type: application/json
 Authorization: {{token}}
 
 {
-  "userId": "2",
+  "userId": "1",
   "hubId": "9b1deb4d-3b7d-4bad-9bdd-2b0d7b3dcb6d",
   "shipperType": "HUB_SHIPPER"
 }
@@ -24,5 +24,5 @@ Authorization: {{token}}
 }
 
 ### shipper 삭제 API
-DELETE http://localhost:19091/api/shippers/c15a097c-0474-4838-ae1f-89780f100ee6
+DELETE http://localhost:19091/api/shippers/985d6aed-363b-468c-a567-9531f99c3b66
 Authorization: {{token}}

--- a/com.three-iii.user/src/main/java/com/three_iii/user/config/JPAConfig.java
+++ b/com.three-iii.user/src/main/java/com/three_iii/user/config/JPAConfig.java
@@ -1,14 +1,16 @@
 package com.three_iii.user.config;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.three_iii.user.domain.AuditorAwareImpl;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.AuditorAware;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @Configuration
-@EnableJpaAuditing
+@EnableJpaAuditing(auditorAwareRef = "auditorProvider")
 public class JPAConfig {
 
     @PersistenceContext
@@ -18,4 +20,10 @@ public class JPAConfig {
     public JPAQueryFactory queryFactory() {
         return new JPAQueryFactory(entityManager);
     }
+
+    @Bean
+    public AuditorAware<String> auditorProvider() {
+        return new AuditorAwareImpl();
+    }
+
 }

--- a/com.three-iii.user/src/main/java/com/three_iii/user/domain/AuditorAwareImpl.java
+++ b/com.three-iii.user/src/main/java/com/three_iii/user/domain/AuditorAwareImpl.java
@@ -1,0 +1,20 @@
+package com.three_iii.user.domain;
+
+import java.util.Optional;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+public class AuditorAwareImpl implements AuditorAware<String> {
+
+
+    @Override
+    public Optional<String> getCurrentAuditor() {
+        return Optional.ofNullable(SecurityContextHolder.getContext().getAuthentication())
+            .map(authentication -> {
+                if (authentication.getPrincipal() instanceof UserPrincipal) {
+                    return ((UserPrincipal) authentication.getPrincipal()).getUsername();
+                }
+                return null;
+            });
+    }
+}

--- a/com.three-iii.user/src/main/java/com/three_iii/user/domain/BaseEntity.java
+++ b/com.three-iii.user/src/main/java/com/three_iii/user/domain/BaseEntity.java
@@ -6,12 +6,14 @@ import jakarta.persistence.MappedSuperclass;
 import jakarta.persistence.Temporal;
 import jakarta.persistence.TemporalType;
 import java.time.LocalDateTime;
+import java.util.Optional;
 import lombok.Getter;
 import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedBy;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import org.springframework.security.core.context.SecurityContextHolder;
 
 @Getter
 @MappedSuperclass
@@ -45,5 +47,13 @@ public abstract class BaseEntity {
     public void delete() {
         this.is_delete = true;
         this.deletedAt = LocalDateTime.now();
+        this.deletedBy = Optional.ofNullable(SecurityContextHolder.getContext().getAuthentication())
+            .map(authentication -> {
+                if (authentication.getPrincipal() instanceof UserPrincipal) {
+                    return ((UserPrincipal) authentication.getPrincipal()).getUsername(); // UserPrincipal에서 원하는 필드 사용
+                }
+                return null;
+            })
+            .orElse("anonymous");
     }
 }

--- a/com.three-iii.user/src/main/java/com/three_iii/user/domain/User.java
+++ b/com.three-iii.user/src/main/java/com/three_iii/user/domain/User.java
@@ -21,7 +21,7 @@ import lombok.NoArgsConstructor;
         @UniqueConstraint(name = "UK_USER_SLACK_ID", columnNames = "slack_id")
     })
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class User {
+public class User extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)


### PR DESCRIPTION
## 개요
AuditorAware 를 구현하여 현재 인증된 사용자 정보를 BaseEntity 필드에 자동으로 주입합니다.

## 작업 내용
- AuditorAware 구현

close #49 

## 공유할 내용
- 자신의 app에 `JPAConfig` `AuditorAwareImpl` `BaseEntity` 클래스 파일 복붙하기
- 도메인에 `BaseEntity`를 상속하면 create, update, delete 시 정상적으로 사용자 정보를 주입합니다.
