### PR TITLE
feat(#50): slack swagger&auth 연결

### DIFF
--- a/com.three-iii.gateway/src/main/resources/application.yml
+++ b/com.three-iii.gateway/src/main/resources/application.yml
@@ -54,6 +54,10 @@ spring:
           uri: lb://company
           predicates:
             - Path=/api/companies/**, /api/products/**
+        - id: slack
+          uri: lb://slack-service
+          predicates:
+            - Path=/api/slack-messages/**
       discovery:
         locator:
           enabled: true

--- a/com.three-iii.slack/build.gradle
+++ b/com.three-iii.slack/build.gradle
@@ -28,12 +28,15 @@ ext {
 }
 
 dependencies {
+    // security
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+
     // swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
 
     // slack
     implementation 'com.slack.api:slack-api-client:1.7.0'
-    
+
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'

--- a/com.three-iii.slack/src/main/java/com/three_iii/slack/ScheduleService.java
+++ b/com.three-iii.slack/src/main/java/com/three_iii/slack/ScheduleService.java
@@ -24,8 +24,8 @@ public class ScheduleService {
     @Scheduled(cron = " 0 0/1 * * * *")
     //@Scheduled(cron = " 0 0 6 * * *") //매일 6시에 실행
     public void companyShipperSchedule() throws SlackApiException, IOException {
-        String weatherInfo = weatherService.getWeather();
-        log.info("날씨 {}", weatherInfo);
+        //String weatherInfo = weatherService.getWeather();
+        //log.info("날씨 {}", weatherInfo);
 
         //slackService.createSlackMessage(new SlackDto("U07MM562S56", "메시지 테스트 입니다"));
     }

--- a/com.three-iii.slack/src/main/java/com/three_iii/slack/config/SecurityConfig.java
+++ b/com.three-iii.slack/src/main/java/com/three_iii/slack/config/SecurityConfig.java
@@ -1,0 +1,44 @@
+package com.three_iii.slack.config;
+
+import static org.springframework.security.config.http.SessionCreationPolicy.STATELESS;
+
+import com.three_iii.slack.filter.AuthenticationFilter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer.FrameOptionsConfig;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@EnableMethodSecurity
+@Configuration
+@RequiredArgsConstructor
+@EnableWebSecurity
+public class SecurityConfig {
+
+    private final AuthenticationFilter authenticationFilter;
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+
+        return http
+            .csrf(AbstractHttpConfigurer::disable)
+            .formLogin(AbstractHttpConfigurer::disable)
+            .httpBasic(AbstractHttpConfigurer::disable)
+            .headers(headers -> headers.frameOptions(FrameOptionsConfig::disable))
+            .sessionManagement(session -> session
+                .sessionCreationPolicy(STATELESS))
+            .authorizeHttpRequests(auth -> auth
+                .requestMatchers("/api/slack-messages/v3/api-docs")
+                .permitAll()
+                .anyRequest().authenticated()
+            )
+            .addFilterBefore(authenticationFilter, UsernamePasswordAuthenticationFilter.class)
+            .build();
+    }
+
+}

--- a/com.three-iii.slack/src/main/java/com/three_iii/slack/config/SwaggerConfig.java
+++ b/com.three-iii.slack/src/main/java/com/three_iii/slack/config/SwaggerConfig.java
@@ -1,29 +1,57 @@
 package com.three_iii.slack.config;
 
-import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
-import io.swagger.v3.oas.annotations.security.SecurityScheme;
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
-import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+import java.util.ArrayList;
+import java.util.List;
+import org.springdoc.core.models.GroupedOpenApi;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+@OpenAPIDefinition(
+    info = @Info(title = "Slack API 명세서",
+        description = "Slack API 명세서",
+        version = "v1"))
 @Configuration
-@SecurityScheme(
-    name = "bearerAuth",
-    type = SecuritySchemeType.HTTP,
-    bearerFormat = "JWT",
-    scheme = "bearer"
-)
 public class SwaggerConfig {
 
+    @Value("${server.port}")
+    String serverPort;
+
     @Bean
-    public OpenAPI customizeOpenAPI() {
+    public GroupedOpenApi publicAPI() {
+        return GroupedOpenApi.builder()
+            .group("com.three-iii.slack")
+            .pathsToMatch("/**")
+            .build();
+    }
 
-        Info info = new Info()
-            .title("AI_B2B_Project")
-            .description("✨ 대규모 AI 시스템 설계 프로젝트 ✨");
-
+    @Bean
+    public OpenAPI customOpenAPI() {
+        List<Server> serverList = new ArrayList<>();
+        Server server = new Server()
+            .url("http://localhost" + ":" + serverPort)
+            .description("Server");
+        Server gatewayServer = new Server()
+            .url("http://localhost" + ":" + 19091)
+            .description("Gateway Server");
+        serverList.add(gatewayServer);
+        serverList.add(server);
         return new OpenAPI()
-            .info(info);
+            .servers(serverList)
+            .components(new Components()
+                .addSecuritySchemes("JWT-Token", new SecurityScheme()
+                    .type(SecurityScheme.Type.HTTP)
+                    .scheme("bearer")
+                    .bearerFormat("JWT")
+                    .in(SecurityScheme.In.HEADER)
+                    .name("Authorization")))
+            .addSecurityItem(new SecurityRequirement().addList("JWT-Token"));
     }
 }

--- a/com.three-iii.slack/src/main/java/com/three_iii/slack/domain/UserPrincipal.java
+++ b/com.three-iii.slack/src/main/java/com/three_iii/slack/domain/UserPrincipal.java
@@ -1,0 +1,17 @@
+package com.three_iii.slack.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UserPrincipal {
+
+    private final Long id;
+    private final String username;
+    private final String role;
+
+    public static UserPrincipal of(Long id, String username, String role) {
+        return new UserPrincipal(id, username, role);
+    }
+}

--- a/com.three-iii.slack/src/main/java/com/three_iii/slack/filter/AuthenticationFilter.java
+++ b/com.three-iii.slack/src/main/java/com/three_iii/slack/filter/AuthenticationFilter.java
@@ -1,0 +1,52 @@
+package com.three_iii.slack.filter;
+
+import com.three_iii.slack.domain.UserPrincipal;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Slf4j
+@Component
+public class AuthenticationFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+        FilterChain filterChain) throws ServletException, IOException {
+
+        String id = request.getHeader("X-User-Id");
+        String username = request.getHeader("X-User-Name");
+        String role = request.getHeader("X-User-Role");
+
+        if (id != null && username != null && role != null) {
+            UserPrincipal userPrincipal = UserPrincipal.of(Long.valueOf(id), username, role);
+
+            GrantedAuthority authority = new SimpleGrantedAuthority(userPrincipal.getRole());
+            Authentication authentication = new UsernamePasswordAuthenticationToken(
+                userPrincipal, null, List.of(authority)
+            );
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        } else {
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            return;
+        }
+        filterChain.doFilter(request, response);
+    }
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
+        return StringUtils.startsWithAny(request.getRequestURI(),
+            "/api/slack-messages/v3/api-docs");
+    }
+}

--- a/com.three-iii.slack/src/main/resources/application.yml
+++ b/com.three-iii.slack/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 spring:
   application:
-    name: slack
+    name: slack-service
   datasource:
     url: jdbc:postgresql://localhost:5432/b2b
     username: postgres
@@ -48,3 +48,9 @@ gemini:
   api:
     url: https://generativelanguage.googleapis.com
     key: ${GEMINI_KEY}
+
+springdoc:
+  api-docs:
+    path: /api/slack-messages/v3/api-docs
+  swagger-ui:
+    path: /api/slack-messages/swagger-ui.html


### PR DESCRIPTION
## 개요
slack swagger&auth 연결

## 작업 내용
- slack swagger&auth 연결
-

close #50 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 애플리케이션 이름을 `slack`에서 `slack-service`로 변경하여 브랜드를 반영했습니다.
	- 새로운 API 경로 구성으로 `/api/slack-messages/**` 요청을 처리합니다.
	- API 문서화 경로를 추가하여 사용성을 향상시켰습니다.
	- 사용자 인증 및 권한 부여를 위한 Spring Boot Starter Security 라이브러리를 추가했습니다.

- **버그 수정**
	- 현재 날씨 정보를 기록하는 기능을 제거하여 코드 간결성을 높였습니다.

- **문서화**
	- OpenAPI 구성을 개선하여 API 문서화의 구조와 기능을 향상시켰습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->