### PR TITLE
feat: 배송담당자 타입별 조회 API 구현

### DIFF
--- a/com.three-iii.user/docs/client/auth-api.http
+++ b/com.three-iii.user/docs/client/auth-api.http
@@ -3,9 +3,9 @@ POST http://localhost:19091/api/auth/sign-up
 Content-Type: application/json
 
 {
-  "username": "user",
-  "password": "password",
-  "slackId": "lingu",
+  "username": "user2",
+  "password": "password2",
+  "slackId": "lingu2",
   "master": false,
   "masterToken": ""
 }

--- a/com.three-iii.user/docs/client/shippers-api.http
+++ b/com.three-iii.user/docs/client/shippers-api.http
@@ -5,7 +5,7 @@ Authorization: {{token}}
 
 {
   "userId": "2",
-  "hubId": "75780ec9-754c-468b-a264-e8e26f90b006",
+  "hubId": "75780ec9-754c-468b-a264-e8e26f90b007",
   "shipperType": "HUB_SHIPPER"
 }
 
@@ -15,6 +15,10 @@ Authorization: {{token}}
 
 ### shipper 단건 조회 API
 GET http://localhost:19091/api/shippers/83777343-2ec9-4e92-a3a3-1e5a8dfa1a23
+Authorization: {{token}}
+
+### shipper 타입별 조회 API
+GET http://localhost:19091/api/shippers/type?type=HUB_SHIPPER
 Authorization: {{token}}
 
 ### shipper 수정 API

--- a/com.three-iii.user/docs/client/shippers-api.http
+++ b/com.three-iii.user/docs/client/shippers-api.http
@@ -4,8 +4,8 @@ Content-Type: application/json
 Authorization: {{token}}
 
 {
-  "userId": "1",
-  "hubId": "9b1deb4d-3b7d-4bad-9bdd-2b0d7b3dcb6d",
+  "userId": "2",
+  "hubId": "75780ec9-754c-468b-a264-e8e26f90b006",
   "shipperType": "HUB_SHIPPER"
 }
 

--- a/com.three-iii.user/src/main/java/com/three_iii/user/application/ShipperService.java
+++ b/com.three-iii.user/src/main/java/com/three_iii/user/application/ShipperService.java
@@ -95,11 +95,34 @@ public class ShipperService {
         return response;
     }
 
+    public List<ShipperReadResponse> findByType(String type, UserPrincipal getter) {
+        // Shipper 목록 조회
+        final List<Shipper> shippers = shipperRepository.findByType(ShipperType.valueOf(type));
+
+        final List<UUID> shipperIds = shippers.stream()
+            .map(Shipper::getId)
+            .toList();
+
+        List<ShipperReadResponse> responses = shippers
+            .stream()
+            .map(ShipperReadResponse::fromEntity)
+            .collect(Collectors.toList());
+
+        // TODO hub 이름 feignClient 로 호출해서 매핑해주기
+//        HashMap<UUID, String> hubNames;
+//
+//        responses.forEach(response ->
+//            response.updateHubName(hubNames.get(response.getHubId())));
+
+        return responses;
+    }
+
     @Transactional
     public String update(UUID shipperId, ShipperUpdateRequest request) {
         Shipper shipper = findShipperById(shipperId);
 
-        // TODO Hub 존재 확인 - FeignClient 호출
+        // 허브 존재여부 확인
+        hubClient.getHub(UUID.fromString(request.getHubId()));
 
         shipper.update(request);
         return shipper.getId().toString();

--- a/com.three-iii.user/src/main/java/com/three_iii/user/application/ShipperService.java
+++ b/com.three-iii.user/src/main/java/com/three_iii/user/application/ShipperService.java
@@ -9,6 +9,7 @@ import com.three_iii.user.domain.repository.ShipperRepository;
 import com.three_iii.user.domain.repository.UserRepository;
 import com.three_iii.user.exception.ErrorCode;
 import com.three_iii.user.exception.UserException;
+import com.three_iii.user.infrastructure.HubClient;
 import com.three_iii.user.presentation.dtos.ShipperCreateRequest;
 import com.three_iii.user.presentation.dtos.ShipperReadResponse;
 import com.three_iii.user.presentation.dtos.ShipperUpdateRequest;
@@ -28,6 +29,7 @@ public class ShipperService {
 
     private final ShipperRepository shipperRepository;
     private final UserRepository userRepository;
+    private final HubClient hubClient;
     private final String SHIPPER_ROLE_NAME = "SHIPPER";
 
     @Transactional
@@ -41,7 +43,8 @@ public class ShipperService {
             throw new UserException(ErrorCode.DUPLICATE_SHIPPER);
         }
 
-        // TODO Hub 존재 확인 - FeignClient 호출
+        // 허브 존재여부 확인
+        hubClient.getHub(UUID.fromString(request.getHubId()));
 
         Shipper shipper = Shipper.of(
             ShipperType.valueOf(request.getShipperType()),

--- a/com.three-iii.user/src/main/java/com/three_iii/user/config/FeignConfig.java
+++ b/com.three-iii.user/src/main/java/com/three_iii/user/config/FeignConfig.java
@@ -1,0 +1,26 @@
+package com.three_iii.user.config;
+
+import feign.RequestInterceptor;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+@Configuration
+public class FeignConfig {
+
+    @Bean
+    public RequestInterceptor requestInterceptor() {
+        return requestTemplate -> {
+            ServletRequestAttributes attributes = (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
+            if (attributes != null) {
+                HttpServletRequest request = attributes.getRequest();
+                String accessToken = request.getHeader("Authorization");
+                if (accessToken != null && accessToken.startsWith("Bearer ")) {
+                    requestTemplate.header("Authorization", accessToken);
+                }
+            }
+        };
+    }
+}

--- a/com.three-iii.user/src/main/java/com/three_iii/user/domain/repository/ShipperRepository.java
+++ b/com.three-iii.user/src/main/java/com/three_iii/user/domain/repository/ShipperRepository.java
@@ -1,6 +1,7 @@
 package com.three_iii.user.domain.repository;
 
 import com.three_iii.user.domain.Shipper;
+import com.three_iii.user.domain.ShipperType;
 import com.three_iii.user.domain.User;
 import java.util.List;
 import java.util.Optional;
@@ -20,4 +21,7 @@ public interface ShipperRepository extends JpaRepository<Shipper, UUID> {
 
     @Query("SELECT s FROM Shipper s JOIN FETCH s.user WHERE s.id = :shipperId")
     Optional<Shipper> findById(@Param("shipperId") UUID shipperId);
+
+    @Query("SELECT s FROM Shipper s JOIN FETCH s.user WHERE s.type = :type")
+    List<Shipper> findByType(ShipperType type);
 }

--- a/com.three-iii.user/src/main/java/com/three_iii/user/infrastructure/HubClient.java
+++ b/com.three-iii.user/src/main/java/com/three_iii/user/infrastructure/HubClient.java
@@ -1,9 +1,15 @@
 package com.three_iii.user.infrastructure;
 
+import com.three_iii.user.config.FeignConfig;
+import java.util.UUID;
 import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 
-@FeignClient(name = "hub-service")
+@FeignClient(name = "hub-service", url = "${gateway.url}", configuration = FeignConfig.class)
 public interface HubClient {
 
+    @GetMapping("/api/hubs/{hubId}")
+    String getHub(@PathVariable("hubId") UUID hubId);
 
 }

--- a/com.three-iii.user/src/main/java/com/three_iii/user/presentation/ShipperController.java
+++ b/com.three-iii.user/src/main/java/com/three_iii/user/presentation/ShipperController.java
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -43,6 +44,13 @@ public class ShipperController {
     public Response<ShipperReadResponse> find(@PathVariable(name = "shipperId") String shipperId,
         @AuthenticationPrincipal UserPrincipal userPrincipal) {
         return Response.success((shipperService.find(UUID.fromString(shipperId), userPrincipal)));
+    }
+
+    @GetMapping("/type")
+    public Response<List<ShipperReadResponse>> findByType(
+        @RequestParam(name = "type") String type,
+        @AuthenticationPrincipal UserPrincipal userPrincipal) {
+        return Response.success((shipperService.findByType(type, userPrincipal)));
     }
 
     @PatchMapping("/{shipperId}")

--- a/com.three-iii.user/src/main/resources/application.yml
+++ b/com.three-iii.user/src/main/resources/application.yml
@@ -45,3 +45,6 @@ springdoc:
     path: /api/auth/v3/api-docs
   swagger-ui:
     path: /api/auth/swagger-ui.html
+
+gateway:
+  url: localhost:19091


### PR DESCRIPTION
## 개요
배송담당자 타입별 조회 API를 구현합니다.

## 작업 내용
- 배송담당자 생성 시 허브 FeignClient 연결
- 배송담당자 타입별 조회 API 구현

close #79 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 사용자 등록 API의 페이로드 업데이트 (사용자 이름, 비밀번호, Slack ID 변경).
	- 새로운 API 엔드포인트 추가: 특정 유형의 운송업체를 쿼리할 수 있는 기능.
	- 운송업체 유형에 따라 필터링할 수 있는 기능 추가.

- **버그 수정**
	- API 요청에 대한 사용자 및 허브 ID 값 업데이트.

- **구성**
	- 게이트웨이 서비스와의 상호작용을 위한 새로운 구성 추가.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->