### PR TITLE
feat: 배송담당자 전체조회 시 허브 이름들도 조회할 수 있도록 FeignClient 연동

### DIFF
--- a/com.three-iii.hub/src/main/java/com/three_iii/hub/application/service/HubService.java
+++ b/com.three-iii.hub/src/main/java/com/three_iii/hub/application/service/HubService.java
@@ -8,7 +8,11 @@ import com.three_iii.hub.application.dtos.HubUpdateDto;
 import com.three_iii.hub.domain.Hub;
 import com.three_iii.hub.domain.repository.HubRepository;
 import com.three_iii.hub.exception.ApplicationException;
+import com.three_iii.hub.presentation.dtos.HubNameFindRequest;
+import com.three_iii.hub.presentation.dtos.HubNameFindResponse;
+import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.CachePut;
@@ -65,5 +69,13 @@ public class HubService {
             .orElseThrow(() -> new ApplicationException(NOT_FOUND_HUB));
         hub.update(request);
         return HubResponse.fromEntity(hub);
+    }
+
+    @Transactional(readOnly = true)
+    public HubNameFindResponse findHubName(HubNameFindRequest request) {
+        final List<Hub> hubs = hubRepository.findByIdIn(
+            request.getHubIds().stream().map(hubId -> UUID.fromString(hubId)).collect(
+                Collectors.toList()));
+        return HubNameFindResponse.fromEntity(hubs);
     }
 }

--- a/com.three-iii.hub/src/main/java/com/three_iii/hub/domain/repository/HubRepository.java
+++ b/com.three-iii.hub/src/main/java/com/three_iii/hub/domain/repository/HubRepository.java
@@ -1,9 +1,11 @@
 package com.three_iii.hub.domain.repository;
 
 import com.three_iii.hub.domain.Hub;
+import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface HubRepository extends JpaRepository<Hub, UUID>, HubRepositoryCustom {
 
+    List<Hub> findByIdIn(List<UUID> ids);
 }

--- a/com.three-iii.hub/src/main/java/com/three_iii/hub/presentation/HubController.java
+++ b/com.three-iii.hub/src/main/java/com/three_iii/hub/presentation/HubController.java
@@ -4,6 +4,8 @@ import com.three_iii.hub.application.dtos.HubResponse;
 import com.three_iii.hub.application.service.HubService;
 import com.three_iii.hub.exception.Response;
 import com.three_iii.hub.presentation.dtos.HubCreateRequest;
+import com.three_iii.hub.presentation.dtos.HubNameFindRequest;
+import com.three_iii.hub.presentation.dtos.HubNameFindResponse;
 import com.three_iii.hub.presentation.dtos.HubUpdateRequest;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -67,5 +69,10 @@ public class HubController {
     public Response<?> deleteHub(@PathVariable UUID hubId) {
         hubService.deleteHub(hubId);
         return Response.success("해당 허브가 삭제되었습니다");
+    }
+
+    @PostMapping("/hub-names")
+    public Response<HubNameFindResponse> findHubName(@RequestBody HubNameFindRequest request) {
+        return Response.success(hubService.findHubName(request));
     }
 }

--- a/com.three-iii.hub/src/main/java/com/three_iii/hub/presentation/dtos/HubNameFindRequest.java
+++ b/com.three-iii.hub/src/main/java/com/three_iii/hub/presentation/dtos/HubNameFindRequest.java
@@ -1,0 +1,16 @@
+package com.three_iii.hub.presentation.dtos;
+
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class HubNameFindRequest {
+
+    List<String> hubIds = new ArrayList<>();
+
+}

--- a/com.three-iii.hub/src/main/java/com/three_iii/hub/presentation/dtos/HubNameFindResponse.java
+++ b/com.three-iii.hub/src/main/java/com/three_iii/hub/presentation/dtos/HubNameFindResponse.java
@@ -1,0 +1,23 @@
+package com.three_iii.hub.presentation.dtos;
+
+import com.three_iii.hub.domain.Hub;
+import java.util.HashMap;
+import java.util.List;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class HubNameFindResponse {
+
+    HashMap<UUID, String> hubNames = new HashMap<>();
+
+    public static HubNameFindResponse fromEntity(List<Hub> hubs) {
+        HubNameFindResponse response = new HubNameFindResponse();
+        hubs.forEach(hub -> response.hubNames.put(hub.getId(), hub.getName()));
+        return response;
+    }
+}

--- a/com.three-iii.user/docs/client/test-api.http
+++ b/com.three-iii.user/docs/client/test-api.http
@@ -1,0 +1,48 @@
+### 일반 사용자 회원 가입 API
+POST http://localhost:19091/api/auth/sign-up
+Content-Type: application/json
+
+{
+  "username": "user",
+  "password": "password",
+  "slackId": "lingu",
+  "master": false,
+  "masterToken": ""
+}
+
+### 마스터 관리자 회원 가입 API
+POST http://localhost:19091/api/auth/sign-up
+Content-Type: application/json
+
+{
+  "username": "master",
+  "password": "password",
+  "slackId": "master",
+  "master": true,
+  "masterToken": "MASTER_TOKEN_AI_B2B_THREE_III"
+}
+
+### 마스터 로그인 API
+POST http://localhost:19091/api/auth/sign-in
+Content-Type: application/json
+
+{
+  "username": "master",
+  "password": "password"
+}
+> {%
+  client.global.set("token", response.headers.valueOf("Authorization"))
+%}
+
+
+### 허브 이름 조회
+POST http://localhost:19091/api/hubs/hub-names
+Content-Type: application/json
+Authorization: {{token}}
+
+{
+  "hubIds": [
+    "75780ec9-754c-468b-a264-e8e26f90b007",
+    "9a927b34-15b0-4b24-a216-08a7f7ab12bb"
+  ]
+}

--- a/com.three-iii.user/src/main/java/com/three_iii/user/application/ShipperService.java
+++ b/com.three-iii.user/src/main/java/com/three_iii/user/application/ShipperService.java
@@ -1,5 +1,7 @@
 package com.three_iii.user.application;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.three_iii.user.application.dto.HubNameFindRequest;
 import com.three_iii.user.domain.Role;
 import com.three_iii.user.domain.Shipper;
 import com.three_iii.user.domain.ShipperType;
@@ -13,7 +15,11 @@ import com.three_iii.user.infrastructure.HubClient;
 import com.three_iii.user.presentation.dtos.ShipperCreateRequest;
 import com.three_iii.user.presentation.dtos.ShipperReadResponse;
 import com.three_iii.user.presentation.dtos.ShipperUpdateRequest;
+import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -61,8 +67,8 @@ public class ShipperService {
         // Shipper 목록 조회
         final List<Shipper> shippers = shipperRepository.findAll();
 
-        final List<UUID> shipperIds = shippers.stream()
-            .map(Shipper::getId)
+        final List<String> hubIds = shippers.stream()
+            .map(Shipper::getHubId).map(UUID::toString)
             .toList();
 
         List<ShipperReadResponse> responses = shippers
@@ -70,11 +76,23 @@ public class ShipperService {
             .map(ShipperReadResponse::fromEntity)
             .collect(Collectors.toList());
 
-        // TODO hub 이름 feignClient 로 호출해서 매핑해주기
-//        HashMap<UUID, String> hubNames;
-//
-//        responses.forEach(response ->
-//            response.updateHubName(hubNames.get(response.getHubId())));
+        JsonNode hubNameResponse = hubClient.getHubNames(HubNameFindRequest.from(hubIds));
+        JsonNode hubNamesNode = hubNameResponse.path("result").path("hubNames");
+
+        HashMap<UUID, String> hubNames = new HashMap<>();
+
+        if (hubNamesNode.isObject()) {
+            Iterator<Entry<String, JsonNode>> fields = hubNamesNode.fields();
+            while (fields.hasNext()) {
+                Map.Entry<String, JsonNode> field = fields.next();
+                UUID key = UUID.fromString(field.getKey());
+                String value = field.getValue().asText();
+                hubNames.put(key, value);
+            }
+        }
+
+        responses.forEach(response ->
+            response.updateHubName(hubNames.get(response.getHubId())));
 
         return responses;
     }

--- a/com.three-iii.user/src/main/java/com/three_iii/user/application/dto/HubNameFindRequest.java
+++ b/com.three-iii.user/src/main/java/com/three_iii/user/application/dto/HubNameFindRequest.java
@@ -1,0 +1,20 @@
+package com.three_iii.user.application.dto;
+
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class HubNameFindRequest {
+
+    List<String> hubIds = new ArrayList<>();
+
+    public static HubNameFindRequest from(List<String> hubIds) {
+        return new HubNameFindRequest(hubIds);
+    }
+
+}

--- a/com.three-iii.user/src/main/java/com/three_iii/user/infrastructure/HubClient.java
+++ b/com.three-iii.user/src/main/java/com/three_iii/user/infrastructure/HubClient.java
@@ -1,10 +1,14 @@
 package com.three_iii.user.infrastructure;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.three_iii.user.application.dto.HubNameFindRequest;
 import com.three_iii.user.config.FeignConfig;
 import java.util.UUID;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 
 @FeignClient(name = "hub-service", url = "${gateway.url}", configuration = FeignConfig.class)
 public interface HubClient {
@@ -12,4 +16,6 @@ public interface HubClient {
     @GetMapping("/api/hubs/{hubId}")
     String getHub(@PathVariable("hubId") UUID hubId);
 
+    @PostMapping("/api/hubs/hub-names")
+    JsonNode getHubNames(@RequestBody HubNameFindRequest request);
 }


### PR DESCRIPTION
## 개요
배송담당자 전체조회 시 허브 이름들도 조회할 수 있도록 FeignClient를 연동합니다.

## 작업 내용
- N+1 문제 해결을 위해 허브 이름 조회 API 구현
- 배송담당자 전체조회 시 허브 이름들도 조회할 수 있도록 API 수정

close #82 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 허브 이름 조회를 위한 API 엔드포인트 추가.
	- 허브 ID 목록을 기반으로 허브 이름을 검색하는 기능 추가.
	- 사용자 등록 및 인증을 위한 API 엔드포인트 추가.
	- 허브 이름 요청 및 응답을 위한 DTO 클래스 추가.

- **버그 수정**
	- 없음

- **문서화**
	- API 엔드포인트에 대한 설명 추가.

- **리팩토링**
	- 허브 이름과 관련된 서비스 및 클라이언트 기능 개선.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->